### PR TITLE
Notify when Juici build has been "killed" rather than "failed"

### DIFF
--- a/lib/irc_machine/models/juici_notification.rb
+++ b/lib/irc_machine/models/juici_notification.rb
@@ -18,6 +18,10 @@ module IrcMachine
         data["status"]
       end
 
+      def warnings
+        data["warnings"]
+      end
+
       def url
         "#{opts[:juici_url]}#{data["url"]}"
       end

--- a/lib/irc_machine/plugin/github_juici.rb
+++ b/lib/irc_machine/plugin/github_juici.rb
@@ -101,7 +101,13 @@ class IrcMachine::Plugin::GithubJuici < IrcMachine::Plugin::Base
       # TODO Include some logic for working out if we're done with this route
       # and calling #drop_route!
       payload = ::IrcMachine::Models::JuiciNotification.new(request.body.read, :juici_url => juici_url)
-      notify "#{payload.status} - #{project.name} :: #{commit.branch} :: built in #{payload.time}s :: JuiCI #{payload.url} :: PING #{commit.author_nicks.join(" ")}"
+
+      notification = "#{payload.status} - #{project.name} :: #{commit.branch} :: built in #{payload.time}s :: JuiCI #{payload.url} :: PING #{commit.author_nicks.join(" ")}"
+      unless payload.warnings.empty?
+        notification << " WARNINGS: #{payload.warnings.join(" ")}"
+      end
+
+      notify notification
       mark_build(commit, payload.status, payload.url)
 
       notify_callback = lambda { |str| notify str }


### PR DESCRIPTION
When I kill a build in Juici, it currently tells me the build has failed in the IRC channel. It would be good if it told me it was killed.